### PR TITLE
Fix MIGRATION_8_9 and add migration test + docs

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,0 +1,48 @@
+name: Android migration test
+
+on:
+  push:
+    branches: [ feature/order-editor-ui, main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  migration-test:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /opt/hostedtoolcache/jdk/17/x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install Android SDK
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 31
+          target: default
+          arch: x86_64
+          force-avd-creation: true
+
+      - name: Build app
+        run: ./gradlew assembleDebug --no-daemon --console=plain
+
+      - name: Run migration instrumentation test
+        run: |
+          ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.extrotarget.extropos.data.local.AppDatabaseMigrationTest --no-daemon --console=plain
+        timeout-minutes: 30

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,15 @@ android {
     }
 }
 
+// Force consistent kotlinx.serialization versions to avoid AbstractMethodError from mixed runtimes
+configurations.all {
+    resolutionStrategy {
+        force 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.1',
+              'org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.8.1',
+              'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
+    }
+}
+
 dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.core.ktx
@@ -92,6 +101,10 @@ dependencies {
     implementation libs.room.runtime
     implementation libs.room.ktx
     kapt libs.room.compiler
+    // Ensure kotlinx.serialization is available to annotation processors (Room schema export)
+    // This prevents AbstractMethodError when Room's annotation processor deserializes schema JSON
+    kapt 'org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3'
+    kapt 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
     // No explicit kapt kotlinx-metadata-jvm entry; rely on compatible processor versions.
     implementation project(':modules:feature-printer')
     // AndroidX Security for EncryptedSharedPreferences (LocalAuthManager)
@@ -113,7 +126,7 @@ dependencies {
     // Room testing helpers for unit tests
     testImplementation 'androidx.room:room-testing:2.7.0'
     // Ensure serialization runtime available during tests
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
     testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     // Instrumentation tests (Espresso + AndroidX Test)
@@ -123,11 +136,14 @@ dependencies {
     // Room testing helper for migration tests
     androidTestImplementation "androidx.room:room-testing:2.7.0"
     // Needed by Room's schema parsing during instrumentation tests
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
-    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3'
+    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
+    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.1'
+    androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.8.1'
 
     // Ensure runtime is present in the app process when running instrumentation tests
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
+    kapt 'org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.8.1'
+    kapt 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'

--- a/app/src/main/java/com/extrotarget/extropos/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/extrotarget/extropos/data/local/AppDatabase.kt
@@ -47,7 +47,7 @@ import com.extrotarget.extropos.printer.data.PrinterDao
         KeyValueEntity::class,
         LocalChangeEntity::class
     ],
-    version = 8, // Updated version for table sections and layouts
+    version = 9, // Bump to 9: add corrective migration to fix tables schema mismatch
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -76,13 +76,11 @@ abstract class AppDatabase : RoomDatabase() {
         private const val DB_NAME = "extropos.db"
 
         fun create(context: Context): AppDatabase {
-            // NOTE: For development and to unblock device testing we enable
-            // destructive migration fallback. This will wipe and recreate the DB
-            // when an unknown/unsupported migration is encountered.
-            // Replace with proper migrations before shipping to production.
+            // Use explicit migrations (no destructive fallback) so on-device data is
+            // preserved. We add a corrective migration 8->9 below to patch older
+            // schemas that are missing recently added columns.
             return Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
-                .fallbackToDestructiveMigration()
+                .addMigrations(*ALL_MIGRATIONS)
                 .build()
         }
 
@@ -589,7 +587,125 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 8 -> 9: robust migration that recreates the
+        // `tables` table with the full expected schema, copies data from the old
+        // table using safe defaults for missing columns, then swaps tables. This
+        // approach handles older variants where some columns/nullable flags differ.
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                try {
+                    // Detect existing columns in the current `tables` table
+                    val cursor = db.query("PRAGMA table_info('tables')")
+                    val existing = mutableSetOf<String>()
+                    while (cursor.moveToNext()) {
+                        val nameIdx = cursor.getColumnIndex("name")
+                        if (nameIdx >= 0) {
+                            existing.add(cursor.getString(nameIdx))
+                        }
+                    }
+                    cursor.close()
+
+                    // Define the desired final column list and create SQL
+                    val cols = listOf(
+                        "id",
+                        "number",
+                        "capacity",
+                        "status",
+                        "currentOrderId",
+                        "section",
+                        "tableType",
+                        "positionX",
+                        "positionY",
+                        "width",
+                        "height",
+                        "rotation",
+                        "assignedServerId",
+                        "lastServedAt",
+                        "estimatedOccupancyTime",
+                        "specialNotes",
+                        "isReservable",
+                        "minimumSpendCents",
+                        "depositRequiredCents",
+                        "createdAt",
+                        "updatedAt",
+                        "isActive",
+                        "isSmokingAllowed",
+                        "isAccessible",
+                        "hasPowerOutlet",
+                        "priority"
+                    )
+
+                                        val createSql = """
+                                                CREATE TABLE IF NOT EXISTS `__tables_new` (
+                                                    `id` TEXT NOT NULL PRIMARY KEY,
+                                                    `number` TEXT NOT NULL,
+                                                    `capacity` INTEGER NOT NULL,
+                                                    `status` TEXT NOT NULL,
+                                                    `currentOrderId` TEXT,
+                                                    `section` TEXT,
+                                                    `tableType` TEXT,
+                                                    `positionX` REAL,
+                                                    `positionY` REAL,
+                                                    `width` REAL,
+                                                    `height` REAL,
+                                                      `rotation` REAL,
+                                                    `assignedServerId` TEXT,
+                                                    `lastServedAt` INTEGER,
+                                                    `estimatedOccupancyTime` INTEGER,
+                                                    `specialNotes` TEXT,
+                                                    `isReservable` INTEGER NOT NULL,
+                                                    `minimumSpendCents` INTEGER,
+                                                    `depositRequiredCents` INTEGER,
+                                                    `createdAt` INTEGER NOT NULL,
+                                                    `updatedAt` INTEGER NOT NULL,
+                                                    `isActive` INTEGER NOT NULL,
+                                                    `isSmokingAllowed` INTEGER NOT NULL,
+                                                    `isAccessible` INTEGER NOT NULL,
+                                                    `hasPowerOutlet` INTEGER NOT NULL,
+                                                    `priority` INTEGER NOT NULL
+                                                )
+                                        """.trimIndent()
+
+                    db.execSQL(createSql)
+
+                    // Build SELECT expressions that either use the existing column
+                    // value or a safe default when the column is missing.
+                    val selectExprs = cols.map { col ->
+                        if (existing.contains(col)) {
+                            "`$col`"
+                        } else {
+                            when (col) {
+                                "id" -> "''"
+                                "number" -> "''"
+                                "capacity" -> "0"
+                                "status" -> "''"
+                                "currentOrderId", "section", "tableType", "positionX", "positionY", "width", "height", "assignedServerId", "specialNotes", "minimumSpendCents", "depositRequiredCents" -> "NULL"
+                                "rotation" -> "0.0"
+                                "lastServedAt", "estimatedOccupancyTime", "createdAt", "updatedAt", "priority" -> "0"
+                                "isReservable" -> "1"
+                                "isActive" -> "1"
+                                "isSmokingAllowed" -> "0"
+                                "isAccessible" -> "1"
+                                "hasPowerOutlet" -> "0"
+                                else -> "NULL"
+                            }
+                        }
+                    }
+
+                    val insertSql = "INSERT INTO `__tables_new` (${cols.joinToString(",")}) SELECT ${selectExprs.joinToString(",")} FROM `tables`"
+                    db.execSQL(insertSql)
+
+                    db.execSQL("DROP TABLE IF EXISTS `tables`")
+                    db.execSQL("ALTER TABLE `__tables_new` RENAME TO `tables`")
+                } catch (e: Exception) {
+                    // If anything fails, log and rethrow so migration doesn't silently succeed
+                    android.util.Log.w("AppDatabase", "MIGRATION_8_9 failed: ${e.message}")
+                    throw e
+                }
+            }
+        }
+
         // Publicly expose migrations for use in tests
-        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
     }
 }

--- a/docs/MIGRATION_8_9.md
+++ b/docs/MIGRATION_8_9.md
@@ -30,3 +30,21 @@ Notes for maintainers
 
 - If you change the `TableEntity` fields (nullability, types or names), update the migration and exported schema via Room's `exportSchema` so the migration logic and the exported JSON remain consistent.
 - Prefer the create-new-table/copy/drop/rename pattern for complex schema changes (adding NOT NULL columns) to keep migrations deterministic.
+
+Local run (developer)
+
+1. Build and run the single migration instrumentation test on a connected device or emulator:
+
+```bash
+./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.extrotarget.extropos.data.local.AppDatabaseMigrationTest --no-daemon --console=plain
+```
+
+2. The test uses the asset at `app/src/androidTest/assets/extropos_pre_v8.db`. If you want to use a different pre-migration DB, replace that file before running the test.
+
+CI notes
+
+- The CI workflow `.github/workflows/migration-test.yml` runs the same focused test on an Android emulator. The workflow provisions an emulator (API 31 x86_64), builds the app and runs the single instrumentation class.
+- Storing large binary DB snapshots in the repo is generally discouraged. Alternatives:
+  - Store the pre-migration DB in release artifacts and download it in the workflow before the test run.
+  - Use Git LFS if you must keep the DB in the repo.
+  - Generate a pre-migration DB programmatically in a unit-test if possible, which is faster and keeps CI light-weight.

--- a/docs/MIGRATION_8_9.md
+++ b/docs/MIGRATION_8_9.md
@@ -1,0 +1,32 @@
+# MIGRATION_8_9 — Tables schema corrective migration
+
+Summary
+
+This note documents the corrective migration added in `AppDatabase.MIGRATION_8_9` (v8 → v9).
+
+Problem
+
+Some on-device pre-v8 databases contained variants of the `tables` table where columns were missing or had different `NOT NULL` or `DEFAULT` definitions. Room's strict schema verification (used by `MigrationTestHelper`) will reject a migration if the final database schema does not match the exported schema JSON in `app/schemas/.../9.json`.
+
+Fix applied
+
+- `MIGRATION_8_9` now:
+  - Creates a new `__tables_new` table whose DDL matches Room's exported schema for version 9 (column names, affinities, and nullability), avoiding unexpected `DEFAULT` clauses that previously caused mismatches.
+  - Detects existing columns in the current `tables` table and builds an INSERT SELECT to copy rows; when a column is missing it substitutes a safe default value so data is preserved and the new NOT NULL columns are populated.
+  - Swaps the tables by dropping the old table and renaming the new table.
+
+Why this is safe
+
+- Creating a new table and copying rows ensures we can precisely control column definitions including nullability and types.
+- Explicit default substitutions guarantee that NOT NULL constraints are satisfied without losing pre-existing data.
+- If the migration fails the code rethrows the exception so migration won't silently succeed in a bad state.
+
+Testing
+
+- A focused instrumentation test `AppDatabaseMigrationTest` was added/used locally to validate the migration using a pulled pre-v8 DB asset (`app/src/androidTest/assets/extropos_pre_v8.db`). The test runs `MigrationTestHelper` to apply `MIGRATION_8_9` and verifies the final schema matches the exported schema.
+- A GitHub Actions workflow was added at `.github/workflows/migration-test.yml` to run this test in CI on an Android emulator.
+
+Notes for maintainers
+
+- If you change the `TableEntity` fields (nullability, types or names), update the migration and exported schema via Room's `exportSchema` so the migration logic and the exported JSON remain consistent.
+- Prefer the create-new-table/copy/drop/rename pattern for complex schema changes (adding NOT NULL columns) to keep migrations deterministic.

--- a/modules/feature-printer/build.gradle.kts
+++ b/modules/feature-printer/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("plugin.serialization") version "1.9.20"
+    kotlin("plugin.serialization") version "2.1.0"
     id("org.jetbrains.kotlin.kapt")
     id("dagger.hilt.android.plugin")
 }
@@ -39,7 +39,7 @@ dependencies {
     
     // DataStore and Serialization
     implementation("androidx.datastore:datastore-preferences:1.0.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
     
     // DantSu ESC/POS Printer SDK
     implementation("com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.3.0")


### PR DESCRIPTION
This PR fixes the v8→v9 migration (`MIGRATION_8_9`) so the created `tables` table DDL matches Room's exported schema. It also adds:

- A focused GitHub Actions workflow to run the migration instrumentation test (`AppDatabaseMigrationTest`) on an emulator: `.github/workflows/migration-test.yml`.
- Documentation: `docs/MIGRATION_8_9.md` describing the change and rationale.
- Aligns kotlinx.serialization versions across modules to avoid annotation-processing/runtime mismatches during Room schema parsing.

I tested locally and confirmed the migration test passes against a pulled pre-v8 DB asset. Please review and merge to run CI.